### PR TITLE
Fix out of bounds exception in Unity check

### DIFF
--- a/WindowsFormsApp1/Form1.cs
+++ b/WindowsFormsApp1/Form1.cs
@@ -41,7 +41,7 @@ namespace WindowsFormsApp1
                     }
                 }
 
-                if (unityCheck[0] != null)
+                if (!(unityCheck != null && unityCheck.Length >= 0))
                 {
                     string[] gamesList = new string[] { "PMS_Build", "Tube Tycoon" };
                     string[] unityAssets = Directory.GetFiles(unityDirectory, "sharedassets0.assets", SearchOption.AllDirectories);


### PR DESCRIPTION
I've only tested on non-Unity, but don't see why the check would be broken.

Fixes #6 